### PR TITLE
Add ommited character ’ into parsing list

### DIFF
--- a/quiz/parser.py
+++ b/quiz/parser.py
@@ -113,4 +113,4 @@ class Parser(object):
         return content.strip()
 
     def _normalize_items(self, items):
-        return [(k, [*v.splitlines()]) for k, v in items if v]
+        return [(k, [*v.splitlines()]) for k, v in items if k and v]

--- a/quiz/utils.py
+++ b/quiz/utils.py
@@ -10,7 +10,7 @@ from .presets import (
 
 
 def noteng(c):
-    return c in ['—', ',', '[', ']', '(', ')', '\n', "'", '"', ' '] or \
+    return c in ['—', ',', '[', ']', '(', ')', '\n', "'", '"', ' ', '’'] or \
         c not in string.ascii_letters
 
 
@@ -18,7 +18,7 @@ def iseng(c):
     return c in ''.join(
         string.ascii_letters + 
         string.whitespace.replace('\n', '') +
-        string.punctuation.replace('~', '') + '—'
+        string.punctuation.replace('~', '') + '—' + '’'
     )
 
 

--- a/takequiz.py
+++ b/takequiz.py
@@ -8,7 +8,7 @@ from quiz.generator import Generator
 init()
 print(Fore.LIGHTYELLOW_EX + 'Generating HBR quiz out of your notes...' + Fore.LIGHTRED_EX)
 generator = Generator(root='./articles')
-generator.generate_quiz()
+generator.generate_quiz(targets=['단어', '문장'])
 print(Fore.LIGHTGREEN_EX + 'Generated HBR quiz successfully' + Style.RESET_ALL)
 print(Fore.LIGHTCYAN_EX + 'Launching HBR quiz on your default browser' + Style.RESET_ALL)
 webbrowser.open_new_tab('http://localhost:5000')


### PR DESCRIPTION
This PR has fixed parsing problem with the character ’ that you reported in issue #8 

Changes are:

- Add ommited punctuation character ’ into parsing list
- Remove any translation items that has empty key(English) in normalization step. 

Now any item that has either empty English or empty translation will be removed from our quiz list.

Thanks.